### PR TITLE
Update gce.py

### DIFF
--- a/contrib/inventory/gce.py
+++ b/contrib/inventory/gce.py
@@ -90,6 +90,9 @@ import os
 import argparse
 import ConfigParser
 
+import logging
+logging.getLogger('libcloud.common.google').addHandler(logging.NullHandler())
+
 try:
     import json
 except ImportError:


### PR DESCRIPTION
##### Issue Type:

<!--- Please pick one and delete the rest: -->
- Feature Pull Request
- New Module Pull Request
- Bugfix Pull Request
- Docs Pull Request
##### Ansible Version:

```
<!--- Paste verbatim output from “ansible --version” here -->
```
##### Summary:

<!--- Please describe the change and the reason for it -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
##### Example output:

```
<!-- Paste verbatim command output here if necessary -->
```

Got this error when trying to create a google cloud instance and noticed the logging module is missing

 ./gce.py --list
No handlers could be found for logger "libcloud.common.google"
